### PR TITLE
英文Readme跳转回中文的Readme地址不正确

### DIFF
--- a/readme-en.md
+++ b/readme-en.md
@@ -1,7 +1,7 @@
 dotnetClub.net
 ----------------------
 
-**Welcome to the dotnetClub.net project. [点此查看中文说明](https://github.com/jijiechen/dotnetclub/blob/dev/readme.md)。**
+**Welcome to the dotnetClub.net project. [点此查看中文说明](https://github.com/jijiechen/dotnetclub/blob/dev/Readme.md)。**
 
 This project is source code for a discussion website, it demonstrates how ASP.NET Core can be used to make a user generated web application. The online instance of this project is hosted at [dotnetclub.net](http://dotnetclub.net) which is exactly a real community for discussing .NET Core technical topics.
 


### PR DESCRIPTION
英文Readme跳转回中文的Readme地址不正确，url需要全字匹配，否者无法找到对应资源。